### PR TITLE
6. Time curv and delay animation completed

### DIFF
--- a/DesignCode/ContentView.swift
+++ b/DesignCode/ContentView.swift
@@ -11,40 +11,59 @@ import SwiftUI
 struct ContentView: View {
     @State var show: Bool = false
     @State var viewState: CGSize = CGSize.zero
+    @State var showCard: Bool = false
     
     var body: some View {
         ZStack {
             TitleView()
                 .blur(radius: show ? 20 : 0)
-                .animation(.default)
+                .opacity(showCard ? 0.4 : 1.0)
+                .offset(y: showCard ? -200.0 : 0)
+                .animation(
+                    Animation
+                        .default
+                        .delay(0.1)
+            )
             BackCardView()
+                .frame(width: showCard ? 300.0 : 340.0, height: 220.0)
                 .background(show ? Color("card3") : Color("card4"))
                 .cornerRadius(20.0)
                 .shadow(radius: 20.0)
                 .offset(x: 0, y: show ? -400 : -40)
                 .offset(viewState)
-                .scaleEffect(0.9)
+                .offset(y: showCard ? -220 : 0)
+                .scaleEffect(showCard ? 1 : 0.9)
                 .rotationEffect(Angle(degrees: show ? 0 : 10.0))
-                .rotation3DEffect(Angle(degrees: 5.0), axis: (x: 10.0, y: 0.0, z: 0.0))
+                .rotationEffect(Angle(degrees: showCard ? -10.0 : 0))
+                .rotation3DEffect(Angle(degrees: showCard ? 0 : 5.0), axis: (x: 10.0, y: 0.0, z: 0.0))
                 .blendMode(.hardLight)
                 .animation(.spring(response: 0.5, dampingFraction: 0.6, blendDuration: 0))
             BackCardView()
+                .frame(width: 340.0, height: 220.0)
                 .background(show ? Color("card4") : Color("card3"))
                 .cornerRadius(20.0)
                 .shadow(radius: 20.0)
                 .offset(x: 0, y: show ? -200 : -20)
                 .offset(viewState)
-                .scaleEffect(0.95)
+                .offset(y: showCard ? -170 : 0)
+                .scaleEffect(showCard ? 1 : 0.95)
                 .rotationEffect(Angle(degrees: show ? 0 : 5.0))
-                .rotation3DEffect(Angle(degrees: 5.0), axis: (x: 10.0, y: 0.0, z: 0.0))
+                .rotationEffect(Angle(degrees: showCard ? -5.0 : 0))
+                .rotation3DEffect(Angle(degrees: showCard ? 0 : 5.0), axis: (x: 10.0, y: 0.0, z: 0.0))
                 .blendMode(.hardLight)
                 .animation(.spring(response: 0.5, dampingFraction: 0.6, blendDuration: 0))
             CardView()
+                .frame(width: showCard ? 375.0 : 340.0, height: 220.0)
+                .background(Color.black)
+                //.cornerRadius(20.0)
+                .clipShape(RoundedRectangle(cornerRadius: showCard ? 30 : 20, style: .continuous))
+                .shadow(radius: 20.0)
                 .offset(viewState)
+                .offset(y: showCard ? -130 : 0)
                 .blendMode(.hardLight)
                 .animation(.spring(response: 0.3, dampingFraction: 0.6, blendDuration: 0))
                 .onTapGesture {
-                    self.show.toggle()
+                    self.showCard.toggle()
             }
             .gesture(
                 DragGesture().onChanged({ (value) in
@@ -57,8 +76,9 @@ struct ContentView: View {
                 })
             )
             BottomCardView()
+                .offset(x: 0, y: showCard ? 360 : 1000)
                 .blur(radius: show ? 20 : 0)
-                .animation(.default)
+                .animation(.timingCurve(0.2, 0.8, 0.2, 1.0, duration: 0.8))
         }
     }
 }
@@ -91,10 +111,6 @@ struct CardView: View {
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 300.0, height: 110.0, alignment: .top)
         }
-        .frame(width: 340.0, height: 220.0)
-        .background(Color.black)
-        .cornerRadius(20.0)
-        .shadow(radius: 20.0)
     }
 }
 
@@ -103,7 +119,6 @@ struct BackCardView: View {
         VStack {
             Spacer()
         }
-        .frame(width: 340.0, height: 220.0)
     }
 }
 
@@ -142,6 +157,5 @@ struct BottomCardView: View {
         .background(Color.white)
         .cornerRadius(30.0)
         .shadow(radius: 20.0)
-        .offset(x: 0, y: 600)
     }
 }


### PR DESCRIPTION
State
Let's start by setting the animation state to false for showing the bottom card.

@State var showCard = false
Show and Hide Bottom Card
We'll replace the variable for our Tap gesture to toggle showCard instead.

CardView()
.onTapGesture {
    self.showCard.toggle()
    }
By default, the bottom card should be outside of the screen. Let's set it to position y 1000 for now. Later on, we'll learn how to use a dynamic value based on the size of the screen.

BottomCardView()
    .offset(y: showCard ? 360 : 1000)
    .animation(.spring(response: 0.5, dampingFraction: 0.7, blendDuration: 0))
Timing Curve
There are so many ways to animate your content in SwiftUI, including the popular timing curve technique. There are many tools out there that use these values, like CSS and sites like Bezier Curve. A good example is cubic-bezier.com where you can get the 4 values for your animation.

.animation(.timingCurve(0.2, 0.8, 0.2, 1, duration: 0.8))
Delay Animation
The Animation value can have multiple modifiers, allowing you to combine your animation timing with other options such as delay.

.animation(Animation.spring().delay(0.2))
Animate Title
Let’s add something offset and opacity animation to our Title and background image. The following Timing Curve values are what I typically use for web development. Also, I added a delay of 0.1 to add a bit of stagger effect.

TitleView()
  .opacity(showCard ? 0.4 : 1)
  .offset(y: showCard ? -200 : 0)
  .animation(
    Animation
        .timingCurve(0.2, 0.8, 0.2, 1, duration: 0.8)
        .delay(0.1)
)
Repeat Animation and Speed
In addition to delay, you can play with the speed and repeat options for your animation.

// Animation
.repeatCount(3)
.repeatCount(3, autoreverses: false)
.repeatForever()
.repeatForever(autoreverses: true)
.speed(2)
Animate Card
We'll animate the frame and the offset for the main card so that it expands to full view and align with the bottom card.

CardView()
  .frame(width: showCard ? 375 : 340, height: 220)
  .offset(y: showCard ? -100 : 0)
Smooth Corners with Masking
The rounded corners in iOS are unique and stand out from the standard perfect radius. You can find these corners in the App Icons, Control Center UI and Share modals. To create this, you'll need to use a clipShape modifier.

BackCardView()
    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))

CardView()
    .clipShape(RoundedRectangle(cornerRadius: showCard ? 30 : 20, style: .continuous))
Animate Back Cards
For the back cards, we'll do a number of transformations. Make sure to add new modifiers next to existing ones of the same properties. For example, offset modifiers should be together. This helps keep your modifiers organized and prevent having issues with animation lag or UI problems.

BackCardView()
  .frame(width: showCard ? 300 : 340, height: 220)
  .offset(y: showCard ? -180 : 0)
  .scaleEffect(showCard ? 1 : 0.9)
  .rotationEffect(Angle(degrees: showCard ? -10 : 0))
  .rotation3DEffect(Angle(degrees: showCard ? 0 : 10), axis: (x: 10.0, y: 0, z: 0))

BackCardView()
  .frame(width: 340, height: 220)
  .offset(y: showCard ? -140 : 0)
  .scaleEffect(showCard ? 1 : 0.95)
  .rotationEffect(Angle(degrees: showCard ? -5 : 0))
  .rotation3DEffect(Angle(degrees: showCard ? 0 : 5), axis: (x: 10.0, y: 0, z: 0))